### PR TITLE
Bump urfave/cli to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here is the typical usage pattern in `main.go`:
 package main
 
 import (
-        "github.com/urfave/cli"
+        "github.com/urfave/cli/v2"
         "github.com/gruntwork-io/go-commons/entrypoint"
         "github.com/gruntwork-io/go-commons/version"
 )
@@ -56,7 +56,12 @@ func main() {
       app := entrypoint.NewApp()
 
       app.Name = "my-app"
-      app.Author = "Gruntwork <www.gruntwork.io>"
+      app.Authors = []*cli.Author{
+            {
+                Name: "Gruntwork",
+                Email: "www.gruntwork.io",
+            },
+      }
 
       // Set the version number from your app from the Version variable that is passed in at build time in `version` package
       // for more understanding see github.com/gruntwork-io/go-commons/version

--- a/entrypoint/assertions.go
+++ b/entrypoint/assertions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 type RequiredArgsError struct {

--- a/entrypoint/assertions_test.go
+++ b/entrypoint/assertions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 func TestStringFlagRequiredOnMissingFlag(t *testing.T) {
@@ -54,7 +54,7 @@ func TestEnvironmentVarRequiredOnSetEnvVar(t *testing.T) {
 func createSampleAppWithRequiredFlag() *cli.App {
 	app := cli.NewApp()
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name: "the-answer-to-all-problems",
 		},
 	}

--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/go-commons/logging"

--- a/entrypoint/entrypoint_test.go
+++ b/entrypoint/entrypoint_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
+
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 func TestEntrypointGetExitCode(t *testing.T) {
@@ -54,8 +55,8 @@ func TestEntrypointNewAppWrapsAppHelpPrinter(t *testing.T) {
 	app.Writer = fakeStdout
 	args := []string{"houston", "help"}
 	err := app.Run(args)
-	assert.Nil(t, err)
-	assert.Equal(t, fakeStdout.String(), EXPECTED_APP_HELP_OUT)
+	assert.NoError(t, err)
+	assert.Equal(t, EXPECTED_APP_HELP_OUT, fakeStdout.String())
 }
 
 func TestEntrypointNewAppWrapsCommandHelpPrinter(t *testing.T) {
@@ -64,8 +65,8 @@ func TestEntrypointNewAppWrapsCommandHelpPrinter(t *testing.T) {
 	app.Writer = fakeStdout
 	args := []string{"houston", "help", "exec"}
 	err := app.Run(args)
-	assert.Nil(t, err)
-	assert.Equal(t, fakeStdout.String(), EXPECTED_EXEC_CMD_HELP_OUT)
+	assert.NoError(t, err)
+	assert.Equal(t, EXPECTED_EXEC_CMD_HELP_OUT, fakeStdout.String())
 }
 
 func TestEntrypointNewAppHelpPrinterHonorsLineWidthVar(t *testing.T) {
@@ -75,8 +76,8 @@ func TestEntrypointNewAppHelpPrinterHonorsLineWidthVar(t *testing.T) {
 	app.Writer = fakeStdout
 	args := []string{"houston", "help"}
 	err := app.Run(args)
-	assert.Nil(t, err)
-	assert.Equal(t, fakeStdout.String(), EXPECTED_APP_HELP_OUT_120_LINES)
+	assert.NoError(t, err)
+	assert.Equal(t, EXPECTED_APP_HELP_OUT_120_LINES, fakeStdout.String())
 }
 
 func TestEntrypointNewAppCommandHelpPrinterHonorsLineWidthVar(t *testing.T) {
@@ -86,8 +87,8 @@ func TestEntrypointNewAppCommandHelpPrinterHonorsLineWidthVar(t *testing.T) {
 	app.Writer = fakeStdout
 	args := []string{"houston", "help", "exec"}
 	err := app.Run(args)
-	assert.Nil(t, err)
-	assert.Equal(t, fakeStdout.String(), EXPECTED_EXEC_CMD_HELP_OUT_120_LINES)
+	assert.NoError(t, err)
+	assert.Equal(t, EXPECTED_EXEC_CMD_HELP_OUT_120_LINES, fakeStdout.String())
 }
 
 func noop(c *cli.Context) error { return nil }
@@ -100,9 +101,10 @@ func createSampleApp() *cli.App {
 	app.Description = `A CLI tool for interacting with Gruntwork Houston that you can use to authenticate to AWS on the CLI and to SSH to your EC2 Instances.`
 
 	configFlag := cli.StringFlag{
-		Name:  "config, c",
-		Value: "~/.houston/houston.yml",
-		Usage: "The configuration file for houston",
+		Name:    "config",
+		Aliases: []string{"c"},
+		Value:   "~/.houston/houston.yml",
+		Usage:   "The configuration file for houston",
 	}
 
 	portFlag := cli.IntFlag{
@@ -111,7 +113,7 @@ func createSampleApp() *cli.App {
 		Usage: "The TCP port the http server is running on",
 	}
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:      "exec",
 			Usage:     "Execute a command with temporary AWS credentials obtained by logging into Gruntwork Houston",
@@ -130,7 +132,7 @@ Examples:
    houston exec prod -- terraform apply
    houston exec stage -- packer build server.json`,
 			Action: noop,
-			Flags:  []cli.Flag{configFlag, portFlag},
+			Flags:  []cli.Flag{&configFlag, &portFlag},
 		},
 		{
 			Name:      "ssh",
@@ -155,7 +157,7 @@ Examples:
 
    houston ssh grunt@11.22.33.44`,
 			Action: noop,
-			Flags:  []cli.Flag{configFlag, portFlag},
+			Flags:  []cli.Flag{&configFlag, &portFlag},
 		},
 		{
 			Name:        "configure",
@@ -163,7 +165,7 @@ Examples:
 			UsageText:   "houston configure [options]",
 			Description: `The configure command can be used to setup or update the houston configuration file. When you run this command with no arguments, it will prompt you with the minimum required options for getting the CLI up and running. The prompt will include the current value as a default if the configuration file exists.`,
 			Action:      noop,
-			Flags:       []cli.Flag{configFlag},
+			Flags:       []cli.Flag{&configFlag},
 		},
 	}
 	return app

--- a/entrypoint/help_utils.go
+++ b/entrypoint/help_utils.go
@@ -18,7 +18,7 @@ var HelpTextLineWidth = 80
 // - Headers are title cased as opposed to all caps
 // - NAME, VERSION, AUTHOR, COPYRIGHT, and GLOBAL OPTIONS sections are removed
 // - Global options are displayed by name in the usage text
-const CLI_APP_HELP_TEMPLATE = `Usage: {{if .UsageText }}{{.UsageText}}{{else}}{{.HelpName}} {{range $index, $option := .VisibleFlags}}[{{$option.GetName | PrefixedFirstFlagName}}] {{end}}{{if .Commands}}command [options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[args]{{end}}{{end}}{{if .Description}}
+const CLI_APP_HELP_TEMPLATE = `Usage: {{if .UsageText }}{{.UsageText}}{{else}}{{.HelpName}} {{range $index, $option := .VisibleFlags}}[{{$option.Name | PrefixedFirstFlagName}}] {{end}}{{if .Commands}}command [options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[args]{{end}}{{end}}{{if .Description}}
 
 {{.Description}}{{end}}{{if .Commands}}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	goerrors "github.com/go-errors/errors"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // If this error is returned, the program should exit with the given exit code.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
-	github.com/urfave/cli v1.22.4
+	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect

--- a/go.sum
+++ b/go.sum
@@ -812,9 +812,10 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
-github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=


### PR DESCRIPTION
This bumps `urfave/cli` to v2 track. This is an opportunistic upgrade (we're not using any of the features yet) so that we can stay up to date as bugs are fixed.