### PR TITLE
Rename to go-commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-[![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_gruntwork-cli)
-[![GoDoc](https://godoc.org/github.com/gruntwork-io/gruntwork-cli?status.svg)](https://godoc.org/github.com/gruntwork-io/gruntwork-cli)
+[![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_go-commons)
+[![GoDoc](https://godoc.org/github.com/gruntwork-io/go-commons?status.svg)](https://godoc.org/github.com/gruntwork-io/go-commons)
 
-# Gruntwork CLI
+# Gruntwork Go Commons
 
-This repo contains common libraries and helpers we can use to build Gruntwork CLI tools.
+This repo contains common libraries and helpers used by Gruntwork for building CLI tools in Go.
+
+**NOTE: This repo was renamed from gruntwork-cli starting v0.8.0. Update your gruntwork-cli references to go-commons.**
 
 ## Packages
 
@@ -25,7 +27,7 @@ these built-in.
 
 ### entrypoint
 
-Most Gruntwork CLI apps should use this package to run their app, as it takes
+Most CLI apps built by Gruntwork should use this package to run their app, as it takes
 care of common tasks such as setting the proper exit code, rendering stack
 traces, handling panics, and rendering help text in a standard format. Note
 that this package assumes you are using
@@ -39,8 +41,8 @@ package main
 
 import (
         "github.com/urfave/cli"
-        "github.com/gruntwork-io/gruntwork-cli/entrypoint"
-        "github.com/gruntwork-io/gruntwork-cli/version"
+        "github.com/gruntwork-io/go-commons/entrypoint"
+        "github.com/gruntwork-io/go-commons/version"
 )
 
 func main() {
@@ -52,7 +54,7 @@ func main() {
       app.Author = "Gruntwork <www.gruntwork.io>"
 
       // Set the version number from your app from the VERSION variable that is passed in at build time in `version` package
-      // for more understanding see github.com/gruntwork-io/gruntwork-cli/version
+      // for more understanding see github.com/gruntwork-io/go-commons/version
       app.Version = version.Version()
 
       app.Action = func(cliContext *cli.Context) error {

--- a/entrypoint/entrypoint.go
+++ b/entrypoint/entrypoint.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/urfave/cli"
 
-	"github.com/gruntwork-io/gruntwork-cli/errors"
-	"github.com/gruntwork-io/gruntwork-cli/logging"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/go-commons/logging"
 )
 
 const defaultSuccessExitCode = 0

--- a/entrypoint/entrypoint_test.go
+++ b/entrypoint/entrypoint_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/files/files.go
+++ b/files/files.go
@@ -3,7 +3,7 @@ package files
 import (
 	"os"
 	"io/ioutil"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 // Return true if the given file exists

--- a/files/paths.go
+++ b/files/paths.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"io/ioutil"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/mattn/go-zglob"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gruntwork-io/gruntwork-cli
+module github.com/gruntwork-io/go-commons
 
 go 1.13
 

--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 // Run the specified shell command with the specified arguments. Connect the command's stdin, stdout, and stderr to

--- a/shell/cmd_test.go
+++ b/shell/cmd_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/gruntwork-cli/logging"
+	"github.com/gruntwork-io/go-commons/logging"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/shell/options.go
+++ b/shell/options.go
@@ -1,7 +1,7 @@
 package shell
 
 import (
-	"github.com/gruntwork-io/gruntwork-cli/logging"
+	"github.com/gruntwork-io/go-commons/logging"
 	"github.com/sirupsen/logrus"
 )
 

--- a/shell/prompt.go
+++ b/shell/prompt.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bgentry/speakeasy"
 	"github.com/fatih/color"
 
-	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 var BRIGHT_GREEN = color.New(color.FgHiGreen, color.Bold)

--- a/url/url.go
+++ b/url/url.go
@@ -2,7 +2,7 @@ package url
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/go-commons/errors"
 	"net/url"
 	"strings"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -3,8 +3,8 @@ package version
 // This variable is set at build time using -ldflags parameters. For example, we typically set this flag in circle.yml
 // to the latest Git tag when building our Go apps:
 //
-// build-go-binaries --app-name my-app --dest-path bin --ld-flags "-X github.com/gruntwork-io/gruntwork-cli/version.VERSION=$CIRCLE_TAG"
-// go build -o my-app -ldflags "-X github.com/gruntwork-io/gruntwork-cli/version.VERSION=v1.0.0"
+// build-go-binaries --app-name my-app --dest-path bin --ld-flags "-X github.com/gruntwork-io/go-commons/version.VERSION=$CIRCLE_TAG"
+// go build -o my-app -ldflags "-X github.com/gruntwork-io/go-commons/version.VERSION=v1.0.0"
 //
 // For more info, see: http://stackoverflow.com/a/11355611/483528
 


### PR DESCRIPTION
This PR renames the references to `gruntwork-cli` to `go-commons`.