### PR TITLE
Add relevant go badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_go-commons)
-[![GoDoc](https://godoc.org/github.com/gruntwork-io/go-commons?status.svg)](https://godoc.org/github.com/gruntwork-io/go-commons)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gruntwork-io/go-commons)](https://goreportcard.com/report/github.com/gruntwork-io/go-commons)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/gruntwork-io/go-commons?tab=overview)
+![go.mod version](https://img.shields.io/github/go-mod/go-version/gruntwork-io/go-commons)
 
 # Gruntwork Go Commons
 


### PR DESCRIPTION
This repo was still pointing to godoc badge, which is now deprecated and replaced by pkg.go.dev, so this PR updates the docs link to use pkg.go.dev.

I also pulled the relevant go badges from terratest (goreportcard and go mod version).