### PR TITLE
Add the ability to configure logger for git functions

### DIFF
--- a/git/auth.go
+++ b/git/auth.go
@@ -12,7 +12,9 @@ import (
 // primary VCS platforms (GitHub, GitLab, BitBucket).
 func ConfigureForceHTTPS(logger *logrus.Logger) error {
 	opts := shell.NewShellOptions()
-	opts.Logger = logger
+	if logger != nil {
+		opts.Logger = logger
+	}
 
 	var allErr error
 
@@ -44,7 +46,9 @@ func ConfigureForceHTTPS(logger *logrus.Logger) error {
 // https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
 func ConfigureHTTPSAuth(logger *logrus.Logger, gitUsername string, gitOauthToken string, vcsHost string) error {
 	opts := shell.NewShellOptions()
-	opts.Logger = logger
+	if logger != nil {
+		opts.Logger = logger
+	}
 
 	if err := shell.RunShellCommand(
 		opts,

--- a/git/auth.go
+++ b/git/auth.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/gruntwork-io/go-commons/shell"
 	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
 )
 
 // ConfigureForceHTTPS configures git to force usage of https endpoints instead of SSH based endpoints for the three
 // primary VCS platforms (GitHub, GitLab, BitBucket).
-func ConfigureForceHTTPS() error {
+func ConfigureForceHTTPS(logger *logrus.Logger) error {
 	opts := shell.NewShellOptions()
+	opts.Logger = logger
 
 	var allErr error
 
@@ -40,8 +42,10 @@ func ConfigureForceHTTPS() error {
 // with git over HTTPS. This uses the cache credentials store to configure the credentials. Refer to the git
 // documentation on credentials storage for more information:
 // https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
-func ConfigureHTTPSAuth(gitUsername string, gitOauthToken string, vcsHost string) error {
+func ConfigureHTTPSAuth(logger *logrus.Logger, gitUsername string, gitOauthToken string, vcsHost string) error {
 	opts := shell.NewShellOptions()
+	opts.Logger = logger
+
 	if err := shell.RunShellCommand(
 		opts,
 		"git", "config", "--global",

--- a/git/git.go
+++ b/git/git.go
@@ -13,7 +13,9 @@ func Clone(logger *logrus.Logger, repo string, targetDir string) error {
 	}
 
 	opts := shell.NewShellOptions()
-	opts.Logger = logger
+	if logger != nil {
+		opts.Logger = logger
+	}
 	return shell.RunShellCommand(opts, "git", "clone", repo, targetDir)
 }
 
@@ -24,7 +26,9 @@ func Checkout(logger *logrus.Logger, ref string, targetDir string) error {
 	}
 
 	opts := shell.NewShellOptions()
-	opts.Logger = logger
+	if logger != nil {
+		opts.Logger = logger
+	}
 	opts.WorkingDir = targetDir
 	return shell.RunShellCommand(opts, "git", "checkout", ref)
 }

--- a/git/git.go
+++ b/git/git.go
@@ -3,25 +3,28 @@ package git
 import (
 	"github.com/gruntwork-io/go-commons/files"
 	"github.com/gruntwork-io/go-commons/shell"
+	"github.com/sirupsen/logrus"
 )
 
 // Clone runs git clone to clone the specified repository into the given target directory.
-func Clone(repo string, targetDir string) error {
+func Clone(logger *logrus.Logger, repo string, targetDir string) error {
 	if !files.IsDir(targetDir) {
 		return TargetDirectoryNotExistsErr{dirPath: targetDir}
 	}
 
 	opts := shell.NewShellOptions()
+	opts.Logger = logger
 	return shell.RunShellCommand(opts, "git", "clone", repo, targetDir)
 }
 
 // Checkout checks out the given ref for the repo cloned in the target directory.
-func Checkout(ref string, targetDir string) error {
+func Checkout(logger *logrus.Logger, ref string, targetDir string) error {
 	if !files.IsDir(targetDir) {
 		return TargetDirectoryNotExistsErr{dirPath: targetDir}
 	}
 
 	opts := shell.NewShellOptions()
+	opts.Logger = logger
 	opts.WorkingDir = targetDir
 	return shell.RunShellCommand(opts, "git", "checkout", ref)
 }

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/go-commons/files"
+	"github.com/gruntwork-io/go-commons/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ func TestGitClone(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir("", "git-test")
 	require.NoError(t, err)
-	require.NoError(t, Clone("https://github.com/gruntwork-io/go-commons.git", tmpDir))
+	require.NoError(t, Clone(logging.GetLogger(t.Name()), "https://github.com/gruntwork-io/go-commons.git", tmpDir))
 	assert.True(t, files.FileExists(filepath.Join(tmpDir, "LICENSE.txt")))
 }
 
@@ -24,7 +25,7 @@ func TestGitCheckout(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir("", "git-test")
 	require.NoError(t, err)
-	require.NoError(t, Clone("https://github.com/gruntwork-io/go-commons.git", tmpDir))
-	require.NoError(t, Checkout("v0.10.0", tmpDir))
+	require.NoError(t, Clone(logging.GetLogger(t.Name()), "https://github.com/gruntwork-io/go-commons.git", tmpDir))
+	require.NoError(t, Checkout(logging.GetLogger(t.Name()), "v0.10.0", tmpDir))
 	assert.False(t, files.FileExists(filepath.Join(tmpDir, "git", "git_test.go")))
 }

--- a/git/test/auth_test.go
+++ b/git/test/auth_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/go-commons/files"
 	"github.com/gruntwork-io/go-commons/git"
+	"github.com/gruntwork-io/go-commons/logging"
 	"github.com/gruntwork-io/terratest/modules/environment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/git/test/auth_test.go
+++ b/git/test/auth_test.go
@@ -19,6 +19,10 @@ const (
 	gitPATEnvName = "GITHUB_OAUTH_TOKEN"
 )
 
+var (
+	logger = logging.GetLogger("testlogger")
+)
+
 // NOTE: All these tests should be run in the provided docker environment to avoid polluting the local git configuration
 // settings. The tests will assert that it is running in the docker environment, and will fail if it is not.
 
@@ -31,11 +35,11 @@ func TestHTTPSAuth(t *testing.T) {
 
 	environment.RequireEnvVar(t, gitPATEnvName)
 	gitPAT := os.Getenv(gitPATEnvName)
-	require.NoError(t, git.ConfigureHTTPSAuth("git", gitPAT, "github.com"))
+	require.NoError(t, git.ConfigureHTTPSAuth(logger, "git", gitPAT, "github.com"))
 
 	tmpDir, err := ioutil.TempDir("", "git-test")
 	require.NoError(t, err)
-	require.NoError(t, git.Clone("https://github.com/gruntwork-io/terraform-aws-lambda.git", tmpDir))
+	require.NoError(t, git.Clone(logger, "https://github.com/gruntwork-io/terraform-aws-lambda.git", tmpDir))
 	assert.True(t, files.IsDir(filepath.Join(tmpDir, "modules/lambda")))
 }
 
@@ -48,11 +52,11 @@ func TestForceHTTPS(t *testing.T) {
 
 	environment.RequireEnvVar(t, gitPATEnvName)
 	gitPAT := os.Getenv(gitPATEnvName)
-	require.NoError(t, git.ConfigureHTTPSAuth("git", gitPAT, "github.com"))
-	require.NoError(t, git.ConfigureForceHTTPS())
+	require.NoError(t, git.ConfigureHTTPSAuth(logger, "git", gitPAT, "github.com"))
+	require.NoError(t, git.ConfigureForceHTTPS(logger))
 
 	tmpDir, err := ioutil.TempDir("", "git-test")
 	require.NoError(t, err)
-	require.NoError(t, git.Clone("git@github.com:gruntwork-io/terraform-aws-lambda.git", tmpDir))
+	require.NoError(t, git.Clone(logger, "git@github.com:gruntwork-io/terraform-aws-lambda.git", tmpDir))
 	assert.True(t, files.IsDir(filepath.Join(tmpDir, "modules/lambda")))
 }


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Sometimes, for security reasons, we may want to suppress the log output of the git commands running. This is not possible with the current functions, as it uses the default logger associated with the `ShellOptions`.

This PR updates the functions in the `git` module to accept the logger object explicitly, and configure it if non-nil.

## Backward compatibility

This PR is backward **incompatible**.

## Migration guide

The functions in the `git` module has been updated to require a `logrus.Logger` object to be passed in to use as the logger for the git commands. You can pass in `nil` for the new arg to retain the old behavior.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
