### PR TITLE
Expose underlying git config calls as functions to further customize credential cache

### DIFF
--- a/git/auth.go
+++ b/git/auth.go
@@ -8,6 +8,30 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// CredentialOptions are the possible configurations options for configuring the git credential-cache helper.
+type CacheCredentialOptions struct {
+	// Host is the VCS host where the cache credential helper should be triggered.
+	// Set to "" if you want to apply the credential cache helper to all hosts.
+	Host string
+
+	// DefaultUsername is the default username to use when authenticating to the VCS host.
+	DefaultUsername string
+
+	// IncludeHTTPPath indicates whether to path through the git http path to the credential helper, enabling matching
+	// with the path (e.g., the org/repo.git component of https://github.com/org/repo.git.
+	IncludeHTTPPath bool
+
+	// SocketPath configures the path to the Unix socket file to use to interact with the cache credential daemon. When
+	// blank, uses the default path baked into the command:
+	// https://git-scm.com/docs/git-credential-cache#_options
+	// This is useful when you are configuring the cache for the same host across multiple paths, as the cache
+	// credential helper is known to break when you have an entry for a specific path and the generic all hosts.
+	SocketPath string
+
+	// Timeout is the timeout in seconds for credentials in the cache.
+	Timeout int
+}
+
 // ConfigureForceHTTPS configures git to force usage of https endpoints instead of SSH based endpoints for the three
 // primary VCS platforms (GitHub, GitLab, BitBucket).
 func ConfigureForceHTTPS(logger *logrus.Logger) error {
@@ -44,19 +68,92 @@ func ConfigureForceHTTPS(logger *logrus.Logger) error {
 // with git over HTTPS. This uses the cache credentials store to configure the credentials. Refer to the git
 // documentation on credentials storage for more information:
 // https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
-func ConfigureHTTPSAuth(logger *logrus.Logger, gitUsername string, gitOauthToken string, vcsHost string) error {
+// NOTE: this configures the cache credential helper globally, with a default timeout of 1 hour. If you want more
+// control over the configuration, use the ConfigureCacheCredentialsHelper and StoreCacheCredentials functions directly.
+func ConfigureHTTPSAuth(
+	logger *logrus.Logger,
+	gitUsername string,
+	gitOauthToken string,
+	vcsHost string,
+) error {
+	// Legacy options that were in use when function was first introduced.
+	cacheOpts := CacheCredentialOptions{
+		Host:            "",
+		DefaultUsername: "",
+		IncludeHTTPPath: false,
+		SocketPath:      "",
+		Timeout:         3600,
+	}
+	if err := ConfigureCacheCredentialsHelper(logger, cacheOpts); err != nil {
+		return err
+	}
+	return StoreCacheCredentials(logger, gitUsername, gitOauthToken, vcsHost, "", "")
+}
+
+// ConfigureCacheCredentialsHelper configures git globally to use the cache credentials helper for authentication based
+// on the provided options configuration.
+func ConfigureCacheCredentialsHelper(logger *logrus.Logger, options CacheCredentialOptions) error {
+	shellOpts := shell.NewShellOptions()
+	if logger != nil {
+		shellOpts.Logger = logger
+	}
+
+	credentialConfigPrefix := "credential"
+	if options.Host != "" {
+		credentialConfigPrefix += fmt.Sprintf(".%s", options.Host)
+	}
+
+	helperOpts := fmt.Sprintf("--timeout %d", options.Timeout)
+	if options.SocketPath != "" {
+		helperOpts += fmt.Sprintf(" --socket %s", options.SocketPath)
+	}
+	if err := shell.RunShellCommand(
+		shellOpts,
+		"git", "config", "--global",
+		credentialConfigPrefix+".helper",
+		"cache "+helperOpts,
+	); err != nil {
+		return err
+	}
+
+	if options.DefaultUsername != "" {
+		if err := shell.RunShellCommand(
+			shellOpts,
+			"git", "config", "--global",
+			credentialConfigPrefix+".username",
+			options.DefaultUsername,
+		); err != nil {
+			return err
+		}
+	}
+
+	if options.IncludeHTTPPath {
+		if err := shell.RunShellCommand(
+			shellOpts,
+			"git", "config", "--global",
+			credentialConfigPrefix+".useHttpPath",
+			"true",
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// StoreCacheCredentials stores the given git credentials for the vcs host and path pair to the git credential-cache
+// helper.
+func StoreCacheCredentials(
+	logger *logrus.Logger,
+	gitUsername string,
+	gitOauthToken string,
+	vcsHost string,
+	vcsPath string,
+	socketPath string,
+) error {
 	opts := shell.NewShellOptions()
 	if logger != nil {
 		opts.Logger = logger
-	}
-
-	if err := shell.RunShellCommand(
-		opts,
-		"git", "config", "--global",
-		"credential.helper",
-		"cache --timeout 3600",
-	); err != nil {
-		return err
 	}
 
 	if gitUsername == "" {
@@ -66,5 +163,14 @@ func ConfigureHTTPSAuth(logger *logrus.Logger, gitUsername string, gitOauthToken
 host=%s
 username=%s
 password=%s`, vcsHost, gitUsername, gitOauthToken)
-	return shell.RunShellCommandWithInput(opts, credentialsStoreInput, "git", "credential-cache", "store")
+	if vcsPath != "" {
+		credentialsStoreInput += fmt.Sprintf("\npath=%s", vcsPath)
+	}
+
+	cmdArgs := []string{"credential-cache"}
+	if socketPath != "" {
+		cmdArgs = append(cmdArgs, "--socket", socketPath)
+	}
+	cmdArgs = append(cmdArgs, "store")
+	return shell.RunShellCommandWithInput(opts, credentialsStoreInput, "git", cmdArgs...)
 }

--- a/git/test/auth_test.go
+++ b/git/test/auth_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gruntwork-io/go-commons/git"
 	"github.com/gruntwork-io/go-commons/logging"
 	"github.com/gruntwork-io/terratest/modules/environment"
+	ttlogger "github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +31,8 @@ var (
 // All these tests are also run in serial to avoid race conditions on the git config file.
 
 func TestHTTPSAuth(t *testing.T) {
+	defer cleanupGitConfig(t)
+
 	currentDir, err := os.Getwd()
 	require.NoError(t, err)
 	require.Equal(t, "/workspace/go-commons/git/test", currentDir)
@@ -43,7 +47,109 @@ func TestHTTPSAuth(t *testing.T) {
 	assert.True(t, files.IsDir(filepath.Join(tmpDir, "modules/lambda")))
 }
 
+func TestHTTPSAuthWithPath(t *testing.T) {
+	defer cleanupGitConfig(t)
+
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.Equal(t, "/workspace/go-commons/git/test", currentDir)
+
+	environment.RequireEnvVar(t, gitPATEnvName)
+	gitPAT := os.Getenv(gitPATEnvName)
+
+	lambdaGitURL := "https://github.com/gruntwork-io/terraform-aws-lambda.git"
+	lambdaOpts := git.CacheCredentialOptions{
+		Host:            lambdaGitURL,
+		DefaultUsername: "git",
+		IncludeHTTPPath: true,
+		SocketPath:      "",
+		Timeout:         3600,
+	}
+	require.NoError(
+		t,
+		git.ConfigureCacheCredentialsHelper(logger, lambdaOpts),
+	)
+	require.NoError(
+		t,
+		git.StoreCacheCredentials(logger, "git", gitPAT, "github.com", "gruntwork-io/terraform-aws-lambda.git", ""),
+	)
+
+	tmpDir, err := ioutil.TempDir("", "git-test")
+	require.NoError(t, err)
+	require.NoError(t, git.Clone(logger, lambdaGitURL, tmpDir))
+	assert.True(t, files.IsDir(filepath.Join(tmpDir, "modules/lambda")))
+}
+
+func TestHTTPSAuthMixed(t *testing.T) {
+	defer cleanupGitConfig(t)
+
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.Equal(t, "/workspace/go-commons/git/test", currentDir)
+
+	// Make sure the directory for git credential sockets exist
+	socketPath := "/tmp/git-credential-sockets"
+	require.NoError(t, os.MkdirAll(socketPath, 0o700))
+	lambdaSocketPath := filepath.Join(socketPath, "lambda")
+	githubSocketPath := filepath.Join(socketPath, "github")
+
+	environment.RequireEnvVar(t, gitPATEnvName)
+	gitPAT := os.Getenv(gitPATEnvName)
+
+	lambdaGitURL := "https://github.com/gruntwork-io/terraform-aws-lambda.git"
+	lambdaOpts := git.CacheCredentialOptions{
+		Host:            lambdaGitURL,
+		DefaultUsername: "git",
+		IncludeHTTPPath: true,
+		SocketPath:      lambdaSocketPath,
+		Timeout:         3600,
+	}
+	require.NoError(
+		t,
+		git.ConfigureCacheCredentialsHelper(logger, lambdaOpts),
+	)
+	require.NoError(
+		t,
+		git.StoreCacheCredentials(logger, "git", gitPAT, "github.com", "gruntwork-io/terraform-aws-lambda.git", lambdaSocketPath),
+	)
+
+	githubOpts := git.CacheCredentialOptions{
+		Host:            "https://github.com",
+		DefaultUsername: "git",
+		IncludeHTTPPath: false,
+		SocketPath:      githubSocketPath,
+		Timeout:         3600,
+	}
+	require.NoError(
+		t,
+		git.ConfigureCacheCredentialsHelper(logger, githubOpts),
+	)
+	require.NoError(
+		t,
+		git.StoreCacheCredentials(logger, "git", "wrong-pat", "github.com", "", githubSocketPath),
+	)
+
+	tmpDir, err := ioutil.TempDir("", "git-test")
+	require.NoError(t, err)
+	lambdaDir := filepath.Join(tmpDir, "terraform-aws-lambda")
+	ciDir := filepath.Join(tmpDir, "terraform-aws-ci")
+	require.NoError(t, os.Mkdir(lambdaDir, 0o755))
+	require.NoError(t, os.Mkdir(ciDir, 0o755))
+
+	require.NoError(
+		t,
+		git.Clone(logger, lambdaGitURL, lambdaDir),
+	)
+	require.Error(
+		t,
+		git.Clone(logger, "https://github.com/gruntwork-io/terraform-aws-ci.git", ciDir),
+	)
+
+}
+
 func TestForceHTTPS(t *testing.T) {
+	defer cleanupGitConfig(t)
+
 	currentDir, err := os.Getwd()
 	require.NoError(t, err)
 	require.Equal(t, "/workspace/go-commons/git/test", currentDir)
@@ -57,4 +163,19 @@ func TestForceHTTPS(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, git.Clone(logger, "git@github.com:gruntwork-io/terraform-aws-lambda.git", tmpDir))
 	assert.True(t, files.IsDir(filepath.Join(tmpDir, "modules/lambda")))
+}
+
+// cleanupGitConfig will reset the git credential cache and git config
+func cleanupGitConfig(t *testing.T) {
+	data, err := ioutil.ReadFile("/root/.gitconfig")
+	require.NoError(t, err)
+	ttlogger.Logf(t, string(data))
+
+	require.NoError(t, os.Remove("/root/.gitconfig"))
+
+	cmd := shell.Command{
+		Command: "git",
+		Args:    []string{"credential-cache", "exit"},
+	}
+	shell.RunCommand(t, cmd)
 }


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

This PR adds two new functions `git.ConfigureCacheCredentialsHelper` and `git.StoreCacheCredentials`. These functions give the CLI more control over the credential caching behavior of git, allowing you to have mixed credentials for accessing different repos.

This is most useful when you are using GitHub Apps for repo access, which can only auth to a single org at a time. In such situation, you need the ability to provide different credentials for different orgs.

<!-- Write a brief description of the changes introduced by this PR -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
