### PR TITLE
Cleanup package docs so they show up in pkg.go.dev

### DIFF
--- a/collections/doc.go
+++ b/collections/doc.go
@@ -1,0 +1,2 @@
+// Package collections contains helper functions for interacting with collection structs like Slices and Maps.
+package collections

--- a/entrypoint/doc.go
+++ b/entrypoint/doc.go
@@ -1,0 +1,3 @@
+// Package entrypoint contains helper functions for setting up a urfave/cli application that can be used as the CLI
+// entrypoint.
+package entrypoint

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors contains helper functions for returning errors from a CLI.
+package errors

--- a/files/doc.go
+++ b/files/doc.go
@@ -1,0 +1,2 @@
+// Package files contains helper functions related to the file system.
+package files

--- a/lock/doc.go
+++ b/lock/doc.go
@@ -1,0 +1,3 @@
+// Package lock contains helper functions for maintaining a lock table and utilizing it to guard critical sections in
+// the code.
+package lock

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -1,0 +1,3 @@
+// Package logging contains helper functions for setting up a CLI wide logger that can be used to log output at various
+// levels.
+package logging

--- a/random/doc.go
+++ b/random/doc.go
@@ -1,0 +1,2 @@
+// Package random provides utilities and functions for generating random data.
+package random

--- a/random/random.go
+++ b/random/random.go
@@ -1,4 +1,3 @@
-// Package random provides utilities and functions for generating random data.
 package random
 
 import (

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -1,0 +1,2 @@
+// Package retry contains helper functions that allow you to retry functions on error.
+package retry

--- a/shell/doc.go
+++ b/shell/doc.go
@@ -1,0 +1,2 @@
+// Package shell contains helper functions for starting and interacting with subprocesses.
+package shell

--- a/shell/output.go
+++ b/shell/output.go
@@ -1,10 +1,11 @@
+package shell
+
 // The structs and functions in this file are almost exactly the same as the version in terratest
 // (https://github.com/gruntwork-io/terratest/blob/37812f27666423c28ea22acb2bac2c80513dd318/modules/shell/output.go),
 // except this version does not trim newlines from the streamed and captured texts. This ensures that the newlines
 // reflect exactly how the underlying shell commands outputted. Otherwise, the newline is always stripped out on the
 // last line, regardless of if the original command included it. That final terminating newline is more significant in
 // production CLI usage vs testing purposes.
-package shell
 
 import (
 	"bufio"

--- a/ssh/doc.go
+++ b/ssh/doc.go
@@ -1,0 +1,2 @@
+// Package ssh allows to manage SSH connections and send commands through them.
+package ssh

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -1,4 +1,3 @@
-// Package ssh allows to manage SSH connections and send commands through them.
 package ssh
 
 import (

--- a/url/doc.go
+++ b/url/doc.go
@@ -1,0 +1,2 @@
+// Package url contains helper functions for dealing with URL strings.
+package url

--- a/url/url.go
+++ b/url/url.go
@@ -2,9 +2,10 @@ package url
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/go-commons/errors"
 	"net/url"
 	"strings"
+
+	"github.com/gruntwork-io/go-commons/errors"
 )
 
 // Create a URL with the given base, path parts, query string, and fragment. This method will properly URI encode

--- a/version/doc.go
+++ b/version/doc.go
@@ -1,0 +1,2 @@
+// Package version contains helper functions for setting and managing CLI versions.
+package version


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description
This PR sets package level documentation for all the modules in `go-commons` so that they show up in [the pkg.go.dev list](https://pkg.go.dev/github.com/gruntwork-io/go-commons#section-directories).
## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
