### PR TITLE
Add a map flatten function

### DIFF
--- a/collections/maps.go
+++ b/collections/maps.go
@@ -31,8 +31,8 @@ func Keys(m map[string]string) []string {
 	return out
 }
 
-// Flatten returns a string slice with key=value items, sorted alphabetically
-func Flatten(m map[string]string) []string {
+// KeyValueStringSlice returns a string slice with key=value items, sorted alphabetically
+func KeyValueStringSlice(m map[string]string) []string {
 	out := []string{}
 
 	for key, value := range m {

--- a/collections/maps.go
+++ b/collections/maps.go
@@ -5,6 +5,10 @@ import (
 	"sort"
 )
 
+const (
+	DefaultKeyValueStringSliceFormat = "%s=%s"
+)
+
 // Merge all the maps into one. Sadly, Go has no generics, so this is only defined for string to interface maps.
 func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
 	out := map[string]interface{}{}
@@ -33,10 +37,16 @@ func Keys(m map[string]string) []string {
 
 // KeyValueStringSlice returns a string slice with key=value items, sorted alphabetically
 func KeyValueStringSlice(m map[string]string) []string {
+	return KeyValueStringSliceWithFormat(m, DefaultKeyValueStringSliceFormat)
+}
+
+// KeyValueStringSliceWithFormat returns a string slice using the specified format, sorted alphabetically.
+// The format should consist of at least two '%s' string verbs.
+func KeyValueStringSliceWithFormat(m map[string]string, format string) []string {
 	out := []string{}
 
 	for key, value := range m {
-		out = append(out, fmt.Sprintf("%s=%s", key, value))
+		out = append(out, fmt.Sprintf(format, key, value))
 	}
 
 	sort.Strings(out)

--- a/collections/maps.go
+++ b/collections/maps.go
@@ -1,9 +1,12 @@
 package collections
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // Merge all the maps into one. Sadly, Go has no generics, so this is only defined for string to interface maps.
-func MergeMaps(maps ... map[string]interface{}) map[string]interface{} {
+func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
 	out := map[string]interface{}{}
 
 	for _, currMap := range maps {
@@ -21,6 +24,19 @@ func Keys(m map[string]string) []string {
 
 	for key, _ := range m {
 		out = append(out, key)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// Flatten returns a string slice with key=value items, sorted alphabetically
+func Flatten(m map[string]string) []string {
+	out := []string{}
+
+	for key, value := range m {
+		out = append(out, fmt.Sprintf("%s=%s", key, value))
 	}
 
 	sort.Strings(out)

--- a/collections/maps_test.go
+++ b/collections/maps_test.go
@@ -140,7 +140,7 @@ func TestKeys(t *testing.T) {
 	}
 }
 
-func TestFlatten(t *testing.T) {
+func TestKeyValueStringSlice(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -153,7 +153,7 @@ func TestFlatten(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprintf("%v", testCase.input), func(t *testing.T) {
-			actual := Flatten(testCase.input)
+			actual := KeyValueStringSlice(testCase.input)
 			assert.Equal(t, testCase.expected, actual)
 		})
 	}

--- a/collections/maps_test.go
+++ b/collections/maps_test.go
@@ -1,9 +1,10 @@
 package collections
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeMapsNoMaps(t *testing.T) {
@@ -123,7 +124,7 @@ func TestKeys(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		input	 map[string]string
+		input    map[string]string
 		expected []string
 	}{
 		{map[string]string{}, []string{}},
@@ -134,6 +135,25 @@ func TestKeys(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprintf("%v", testCase.input), func(t *testing.T) {
 			actual := Keys(testCase.input)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    map[string]string
+		expected []string
+	}{
+		{map[string]string{"a": "foo"}, []string{"a=foo"}},
+		{map[string]string{"a": "foo", "b": "bar", "c": "baz"}, []string{"a=foo", "b=bar", "c=baz"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v", testCase.input), func(t *testing.T) {
+			actual := Flatten(testCase.input)
 			assert.Equal(t, testCase.expected, actual)
 		})
 	}

--- a/collections/maps_test.go
+++ b/collections/maps_test.go
@@ -158,3 +158,24 @@ func TestKeyValueStringSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyValueStringSliceWithFormat(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    map[string]string
+		format   string
+		expected []string
+	}{
+		{map[string]string{"a": "foo"}, "%s='%s'", []string{"a='foo'"}},
+		{map[string]string{"a": "foo"}, "%s%s", []string{"afoo"}},
+		{map[string]string{"a": "foo", "b": "bar", "c": "baz"}, "%s=%s", []string{"a=foo", "b=bar", "c=baz"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v", testCase.input), func(t *testing.T) {
+			actual := KeyValueStringSliceWithFormat(testCase.input, testCase.format)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

This PR introduces a Go Map Flatten function which is useful for turning a map of type `map[string]string` into a string slice of `key=value` items.

