### PR TITLE
Add function to convert key=value slice pairs to map

### DIFF
--- a/collections/maps.go
+++ b/collections/maps.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 const (
@@ -51,5 +52,27 @@ func KeyValueStringSliceWithFormat(m map[string]string, format string) []string 
 
 	sort.Strings(out)
 
+	return out
+}
+
+// KeyValueStringSliceAsMap converts a string slice with key=value items into a map of slice values. The slice will
+// contain more than one item if a key is repeated in the string slice list.
+func KeyValueStringSliceAsMap(kvPairs []string) map[string][]string {
+	out := make(map[string][]string)
+	for _, kvPair := range kvPairs {
+		x := strings.Split(kvPair, "=")
+		key := x[0]
+
+		var value string
+		if len(x) > 1 {
+			value = strings.Join(x[1:], "=")
+		}
+
+		if _, hasKey := out[key]; hasKey {
+			out[key] = append(out[key], value)
+		} else {
+			out[key] = []string{value}
+		}
+	}
 	return out
 }

--- a/collections/maps_test.go
+++ b/collections/maps_test.go
@@ -179,3 +179,57 @@ func TestKeyValueStringSliceWithFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyValueStringSliceAsMap(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    []string
+		expected map[string][]string
+	}{
+		{
+			"BaseCase",
+			[]string{"key=value"},
+			map[string][]string{"key": []string{"value"}},
+		},
+		{"EmptyCase", []string{}, map[string][]string{}},
+		{
+			"RepeatedKey",
+			[]string{"key=valueA", "foo=bar", "key=valueB"},
+			map[string][]string{
+				"key": []string{"valueA", "valueB"},
+				"foo": []string{"bar"},
+			},
+		},
+		{
+			"EmptyValue",
+			[]string{"key", "foo=", "foo=baz"},
+			map[string][]string{
+				"key": []string{""},
+				"foo": []string{"", "baz"},
+			},
+		},
+		{
+			"EqualInValue",
+			[]string{"key=foo=bar"},
+			map[string][]string{
+				"key": []string{"foo=bar"},
+			},
+		},
+		{
+			"EmptyString",
+			[]string{""},
+			map[string][]string{
+				"": []string{""},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := KeyValueStringSliceAsMap(testCase.input)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
This adds a new function that helps with converting a key=value slice of strings to a map. This is useful for working with the return value of `os.Environ()`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

- Added a new function `collections.KeyValueStringSliceAsMap` which can be used to work with a slice of `key=value` pairs.