### PR TITLE
Feature/telemetry forwarder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/go-errors/errors v1.4.2
 	github.com/google/go-github/v44 v44.1.0
+	github.com/google/uuid v1.2.0
 	github.com/gruntwork-io/terratest v0.41.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-zglob v0.0.3
@@ -24,7 +25,6 @@ require (
 	golang.org/x/crypto v0.1.0
 	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
-	vizzlo.com/mixpanel v1.2.0
 )
 
 require (
@@ -62,7 +62,6 @@ require (
 	github.com/google/go-github/v29 v29.0.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -828,5 +828,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-vizzlo.com/mixpanel v1.2.0 h1:ip0yFM9mIgAKDB0yIkUB2y+C2n+6MXaQ0KQk3DyISjE=
-vizzlo.com/mixpanel v1.2.0/go.mod h1:bmKnyCOO+/6SRhjujPG6ARtNJdTRepmA/TH+Nt/1GyU=

--- a/telemetry/mixpanel.go
+++ b/telemetry/mixpanel.go
@@ -1,19 +1,21 @@
 package telemetry
 
 import (
+	"bytes"
+	"encoding/json"
 	"github.com/google/uuid"
 	"log"
+	"net/http"
 	"time"
-
-	"vizzlo.com/mixpanel"
 )
 
+const ForwarderUrl = "https://t.dogfood-dev.com/"
+
 type MixpanelTelemetryTracker struct {
-	clientId string
-	client   *mixpanel.Client
-	appName  string
-	version  string
-	runId    string
+	client  *http.Client
+	appName string
+	version string
+	runId   string
 }
 
 /*
@@ -42,20 +44,38 @@ func (m MixpanelTelemetryTracker) TrackEvent(eventContext EventContext, eventPro
 	// Combine our baseline props that we send for _ALL_ events with the passed in props from the event
 	trackProps := mergeMaps(baseProps, eventProps)
 
-	err := m.client.Track(m.runId, eventContext.EventName, trackProps)
-
+	request := map[string]interface{}{
+		"id":         m.runId,
+		"event":      eventContext.EventName,
+		"eventProps": trackProps,
+	}
+	jsonStr, err := json.Marshal(request)
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+	req, err := http.NewRequest("POST", ForwarderUrl, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.client.Do(req)
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+	err = resp.Body.Close()
 	if err != nil {
 		log.Println(err.Error())
 	}
 }
 
-func NewMixPanelTelemetryClient(clientId string, appName string, version string) MixpanelTelemetryTracker {
-	mixpanelClient := mixpanel.New(clientId)
+func NewMixPanelTelemetryClient(appName string, version string) MixpanelTelemetryTracker {
 	return MixpanelTelemetryTracker{
-		client:   mixpanelClient,
-		clientId: clientId,
-		appName:  appName,
-		version:  version,
-		runId:    uuid.New().String(),
+		client:  &http.Client{},
+		appName: appName,
+		version: version,
+		runId:   uuid.New().String(),
 	}
 }

--- a/telemetry/mixpanel.go
+++ b/telemetry/mixpanel.go
@@ -53,13 +53,7 @@ func (m MixpanelTelemetryTracker) TrackEvent(eventContext EventContext, eventPro
 		log.Println(err.Error())
 		return
 	}
-	req, err := http.NewRequest("POST", m.url, bytes.NewBuffer(jsonStr))
-	if err != nil {
-		log.Println(err.Error())
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := m.client.Do(req)
+	resp, err := m.client.Post(m.url, "application/json", bytes.NewBuffer(jsonStr))
 	if err != nil {
 		log.Println(err.Error())
 		return

--- a/telemetry/mixpanel.go
+++ b/telemetry/mixpanel.go
@@ -9,10 +9,9 @@ import (
 	"time"
 )
 
-const ForwarderUrl = "https://t.dogfood-dev.com/"
-
 type MixpanelTelemetryTracker struct {
 	client  *http.Client
+	url     string
 	appName string
 	version string
 	runId   string
@@ -54,7 +53,7 @@ func (m MixpanelTelemetryTracker) TrackEvent(eventContext EventContext, eventPro
 		log.Println(err.Error())
 		return
 	}
-	req, err := http.NewRequest("POST", ForwarderUrl, bytes.NewBuffer(jsonStr))
+	req, err := http.NewRequest("POST", m.url, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		log.Println(err.Error())
 		return
@@ -71,9 +70,10 @@ func (m MixpanelTelemetryTracker) TrackEvent(eventContext EventContext, eventPro
 	}
 }
 
-func NewMixPanelTelemetryClient(appName string, version string) MixpanelTelemetryTracker {
+func NewMixPanelTelemetryClient(url string, appName string, version string) MixpanelTelemetryTracker {
 	return MixpanelTelemetryTracker{
 		client:  &http.Client{},
+		url:     url,
 		appName: appName,
 		version: version,
 		runId:   uuid.New().String(),


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Migrate to telemetry-forwarder.

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Migration Guide

The application no longer needs to provide a mixpanel_token to the telemetry library
